### PR TITLE
Macro collision and .desktop validation

### DIFF
--- a/src/Screenie/res/screenie.desktop
+++ b/src/Screenie/res/screenie.desktop
@@ -1,5 +1,5 @@
 [Desktop Entry]
-Version=0.1.0
+Version=1.0
 Type=Application
 Name=Screenie
 GenericName=Screenshot composer
@@ -8,7 +8,6 @@ Exec=Screenie %U
 TryExec=Screenie
 Icon=screenie
 Terminal=false
-Categories=Graphics;2DGraphics;RasterGraphics;Qt
+Categories=Graphics;2DGraphics;RasterGraphics;Qt;
 StartupNotify=true
-MimeType=application/x-xsc
-
+MimeType=application/x-xsc;

--- a/src/Utils/src/Version.cpp
+++ b/src/Utils/src/Version.cpp
@@ -22,6 +22,14 @@
 #include <QtCore/QRegExp>
 #include "Version.h"
 
+#ifdef minor
+#undef minor
+#endif
+
+#ifdef major
+#undef major
+#endif
+
 class VersionPrivate
 {
 public:


### PR DESCRIPTION
- The use of major/minor() causes, for me, a symbol collision with macros defined by glibc.
- The provided .desktop file does not validate
